### PR TITLE
Added _JS_Sound_GetPosition() dummy to unity-audio.js to fix missing …

### DIFF
--- a/Runtime/wechat-default/unity-sdk/audio/unity-audio.js
+++ b/Runtime/wechat-default/unity-sdk/audio/unity-audio.js
@@ -1265,4 +1265,7 @@ export default {
         }
         return WEBAudio.audioContext.sampleRate;
     },
+    _JS_Sound_GetPosition() {
+        return 0;
+    },
 };


### PR DESCRIPTION
…function error starting from Unity 2022.3.57f1 and later

Error described in https://github.com/wechat-miniprogram/minigame-unity-webgl-transform/issues/961

Same error occurred on Unity 6000 as well.